### PR TITLE
v3.5.0 rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 About r-cli
 ===========
 
-Home: https://cli.r-lib.org, https://github.com/r-lib/cli#readme
+Home: https://cli.r-lib.org
 
 Package license: MIT
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/r-cli-feedstock/blob/main/LICENSE.txt)
 
 Summary: A suite of tools to build attractive command line interfaces ('CLIs'), from semantic elements: headings, lists, alerts, paragraphs, etc. Supports custom themes via a 'CSS'-like language. It also contains a number of lower level 'CLI' elements: rules, boxes, trees, and 'Unicode' symbols with 'ASCII' alternatives. It support ANSI colors and text styles as well.
+
+Development: https://github.com/r-lib/cli
+
+Documentation: https://cli.r-lib.org/reference/index.html
 
 Current build status
 ====================

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   merge_build_host: true  # [win]
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/
@@ -22,7 +22,6 @@ build:
 requirements:
   build:
     - cross-r-base {{ r_base }}  # [build_platform != target_platform]
-    - r-glue                     # [build_platform != target_platform]
     - {{ compiler('c') }}              # [not win]
     - {{ compiler('m2w64_c') }}        # [win]
     - {{ compiler('cxx') }}            # [not win]
@@ -35,11 +34,9 @@ requirements:
     - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
-    - r-glue
   run:
     - r-base
     - {{ native }}gcc-libs         # [win]
-    - r-glue
 
 test:
   commands:
@@ -47,7 +44,9 @@ test:
     - "\"%R%\" -e \"library('cli')\""  # [win]
 
 about:
-  home: https://cli.r-lib.org, https://github.com/r-lib/cli#readme
+  home: https://cli.r-lib.org
+  dev_url: https://github.com/r-lib/cli
+  doc_url: https://cli.r-lib.org/reference/index.html
   license: MIT
   summary: "A suite of tools to build attractive command line interfaces ('CLIs'), from semantic elements: headings, lists, alerts, paragraphs, etc. Supports custom themes via a 'CSS'-like language. It also contains a number of lower level 'CLI' elements: rules, boxes, trees, and 'Unicode' symbols with 'ASCII' alternatives.\
     \ It support ANSI colors and text styles as well."
@@ -60,24 +59,3 @@ extra:
   recipe-maintainers:
     - conda-forge/r
     - ocefpaf
-
-# Package: cli
-# Title: Helpers for Developing Command Line Interfaces
-# Version: 3.0.1
-# Authors@R: c( person("Gabor", "Csardi", , "csardi.gabor@gmail.com", c("aut", "cre")), person("Hadley", "Wickham", role = c("ctb")), person("Kirill", "Muller", role = c("ctb")), person("RStudio", role = "cph") )
-# Description: A suite of tools to build attractive command line interfaces ('CLIs'), from semantic elements: headings, lists, alerts, paragraphs, etc. Supports custom themes via a 'CSS'-like language. It also contains a number of lower level 'CLI' elements: rules, boxes, trees, and 'Unicode' symbols with 'ASCII' alternatives. It support ANSI colors and text styles as well.
-# License: MIT + file LICENSE
-# URL: https://cli.r-lib.org, https://github.com/r-lib/cli#readme
-# BugReports: https://github.com/r-lib/cli/issues
-# RoxygenNote: 7.1.1.9001
-# Depends: R (>= 2.10)
-# Imports: glue, utils
-# Suggests: callr, covr, grDevices, htmlwidgets, knitr, methods, mockery, prettycode (>= 1.1.0), processx, ps (>= 1.3.4.9000), rlang, rmarkdown, rstudioapi, shiny, testthat, tibble, withr
-# Config/testthat/edition: 3
-# Encoding: UTF-8
-# NeedsCompilation: yes
-# Packaged: 2021-07-16 20:08:00 UTC; gaborcsardi
-# Author: Gabor Csardi [aut, cre], Hadley Wickham [ctb], Kirill Muller [ctb], RStudio [cph]
-# Maintainer: Gabor Csardi <csardi.gabor@gmail.com>
-# Repository: CRAN
-# Date/Publication: 2021-07-17 09:00:01 UTC


### PR DESCRIPTION
Package dropped `r-glue` dependency.

# Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
